### PR TITLE
Compatibility ggplot2 3.6.0

### DIFF
--- a/vignettes/rasterdiv_04_Accumulation_Rao.Rmd
+++ b/vignettes/rasterdiv_04_Accumulation_Rao.Rmd
@@ -131,8 +131,8 @@ geom_line(col="red",lwd=3) +
 geom_area(data=accrao.df,aes(x=alphas,y=rao.t0),fill="red",alpha=0.3,inherit.aes=FALSE) +
 geom_area(data=accrao.df,aes(x=alphas,y=rao.t1),fill="blue",alpha=0.3,inherit.aes=FALSE) +
 geom_line(data=accrao.df,aes(x=alphas,y=rao.t1),col="blue",lwd=3,inherit.aes=FALSE) +
-geom_text(data=cbind.data.frame(x=3.5,y=60),aes(x=x,y=y),label=expression(integral((frac(1, N^4) %.% D^alpha)^(frac(1,alpha)) * dx == 456, alpha==0, 10)),col="red",cex=5,inherit.aes=FALSE) +
-geom_text(data=cbind.data.frame(x=7,y=25),aes(x=x,y=y),label=expression(integral((frac(1, N^4) %.% D^alpha)^(frac(1,alpha)) * dx == 343, alpha==0, 10)),col="blue",cex=5,inherit.aes=FALSE) +
+geom_text(data=cbind.data.frame(x=3.5,y=60),aes(x=x,y=y),label= "integral((frac(1, N^4) %.% D^alpha)^(frac(1,alpha)) * dx == 456, alpha==0, 10)",col="red",cex=5,inherit.aes=FALSE,parse=TRUE) +
+geom_text(data=cbind.data.frame(x=7,y=25),aes(x=x,y=y),label= "integral((frac(1, N^4) %.% D^alpha)^(frac(1,alpha)) * dx == 343, alpha==0, 10)",col="blue",cex=5,inherit.aes=FALSE,parse=TRUE) +
 geom_text(data=cbind.data.frame(x=8,y=72),aes(x=x,y=y),label="Difference = 113",col="black",cex=4,angle=12,inherit.aes=FALSE) +
 ggtitle("AccRao index before, after and difference") +
 theme_bw()


### PR DESCRIPTION
Hi there,

Apologies for not posting an issue first.
The ggplot2 package is planning an update for around May 2025 and a reverse dependency test identified a problem with the rasterdiv package.
The details are explained in https://github.com/tidyverse/ggplot2/issues/6294, but essentially ggplot2 don't accept expressions as labels and we're becoming more strict about this.
This PR changes a few labels to no longer be expressions.
You can test the changes yourself with the development version of ggplot2 (`pak::pak("tidyverse/ggplot2")`)

Best,
Teun